### PR TITLE
Implement `jointSeep()`

### DIFF
--- a/src/joints/buffer-joint.spec.ts
+++ b/src/joints/buffer-joint.spec.ts
@@ -330,5 +330,26 @@ describe('BufferJoint', () => {
         await whenSank;
       });
     });
+
+    describe('supply', () => {
+      it('stops pouring values', async () => {
+        const sank: number[] = [];
+
+        const whenSank = joint.faucet(value => {
+          sank.push(value);
+        });
+
+        joint.pass(1);
+        joint.pass(2);
+        await new Promise<void>(resolve => setImmediate(resolve));
+        expect(sank).toEqual([1, 2]);
+
+        joint.supply.done();
+        joint.pass(3);
+        await whenSank;
+
+        expect(sank).toEqual([1, 2]);
+      });
+    });
   });
 });

--- a/src/joints/buffer-joint.ts
+++ b/src/joints/buffer-joint.ts
@@ -9,21 +9,21 @@ import { DataJoint } from './data-joint.js';
  *
  * Note that the sinking won't complete until the value dropped from buffer or joint supply cut off.
  *
- * @typeParam T - Type of data values poured by {@link DataJoint#faucet joint faucet}.
  * @typeParam TIn - Type of data values accepted by {@link DataJoint#sink joint sink}.
+ * @typeParam TOut - Type of data values poured by {@link DataJoint#faucet joint faucet}.
  */
-export class BufferJoint<out T, in TIn extends T = T>
-  extends DataJoint<T, TIn>
-  implements Iterable<T> {
+export class BufferJoint<in TIn extends TOut, out TOut = TIn>
+  extends DataJoint<TIn, TOut>
+  implements Iterable<TOut> {
 
-  #buffer: BufferJoint.Buffer<T>;
+  #buffer: BufferJoint.Buffer<TOut>;
 
   /**
    * Constructs buffer joint.
    *
    * @param buffer - Either buffer to use, a maximum buffer capacity, or nothing for infinite buffer size. Minimum 0.
    */
-  constructor(buffer?: BufferJoint.Buffer<T> | number) {
+  constructor(buffer?: BufferJoint.Buffer<TOut> | number) {
     super();
 
     if (buffer == null) {
@@ -50,7 +50,7 @@ export class BufferJoint<out T, in TIn extends T = T>
     });
   }
 
-  [Symbol.iterator](): IterableIterator<T> {
+  [Symbol.iterator](): IterableIterator<TOut> {
     return this.values();
   }
 
@@ -59,7 +59,7 @@ export class BufferJoint<out T, in TIn extends T = T>
    *
    * @returns Iterable iterator of buffered values.
    */
-  values(): IterableIterator<T> {
+  values(): IterableIterator<TOut> {
     return this.#buffer[Symbol.iterator]();
   }
 
@@ -87,7 +87,10 @@ export class BufferJoint<out T, in TIn extends T = T>
    *
    * @returns Either nothing, or a promise-like instance resolved when the sink added.
    */
-  protected override async sinkAdded(sink: DataSink<T>, _sinkSupply: Supply<void>): Promise<void> {
+  protected override async sinkAdded(
+    sink: DataSink<TOut>,
+    _sinkSupply: Supply<void>,
+  ): Promise<void> {
     await Promise.all([...this.#buffer].map(async value => await sink(value)));
   }
 

--- a/src/joints/data-joint.ts
+++ b/src/joints/data-joint.ts
@@ -10,14 +10,14 @@ import { sinkAll } from '../sink-all.js';
  *
  * The data sank to the {@link DataJoint#sink sink} is poured to the {@link DataJoint#faucet faucet}.
  *
- * @typeParam T - Type of data values poured by {@link DataJoint#faucet joint faucet}.
  * @typeParam TIn - Type of data values accepted by {@link DataJoint#sink joint sink}.
+ * @typeParam TOut - Type of data values poured by {@link DataJoint#faucet joint faucet}.
  */
-export class DataJoint<out T, in TIn extends T = T> {
+export class DataJoint<in TIn extends TOut, out TOut = TIn> {
 
   readonly #supply = new Supply();
   readonly #sink: DataSink<TIn>;
-  readonly #faucet: DataFaucet<T>;
+  readonly #faucet: DataFaucet<TOut>;
   readonly #sinks = new Map<Supply, DataSink<TIn>>();
 
   /**
@@ -41,7 +41,7 @@ export class DataJoint<out T, in TIn extends T = T> {
     await Promise.all([whenAccepted?.(), whenSank()]);
   }
 
-  async #addSink(sink: DataSink<T>, sinkSupply: SupplyOut): Promise<void> {
+  async #addSink(sink: DataSink<TOut>, sinkSupply: SupplyOut): Promise<void> {
     const supply = new Supply();
 
     supply
@@ -78,7 +78,7 @@ export class DataJoint<out T, in TIn extends T = T> {
   /**
    * Data faucet pouring data values sank to {@link sink joint sink}.
    */
-  get faucet(): DataFaucet<T> {
+  get faucet(): DataFaucet<TOut> {
     return this.#faucet;
   }
 
@@ -160,7 +160,7 @@ export class DataJoint<out T, in TIn extends T = T> {
    *
    * @returns Either nothing, or a promise resolved when the sink added.
    */
-  protected sinkAdded(_sink: DataSink<T>, _sinkSupply: Supply): void | PromiseLike<void> {
+  protected sinkAdded(_sink: DataSink<TOut>, _sinkSupply: Supply): void | PromiseLike<void> {
     // Do nothing.
   }
 

--- a/src/joints/value-joint.ts
+++ b/src/joints/value-joint.ts
@@ -8,12 +8,12 @@ import { DataJoint } from './data-joint.js';
  *
  * Note that the sinking won't complete until another value poured to the joint or joint supply cut off.
  *
- * @typeParam T - Type of data values poured by {@link DataJoint#faucet joint faucet}.
  * @typeParam TIn - Type of data values accepted by {@link DataJoint#sink joint sink}.
+ * @typeParam TOut - Type of data values poured by {@link DataJoint#faucet joint faucet}.
  */
-export class ValueJoint<out T, in TIn extends T = T> extends DataJoint<T, TIn> {
+export class ValueJoint<in TIn extends TOut, out TOut = TIn> extends DataJoint<TIn, TOut> {
 
-  #value: T;
+  #value: TOut;
   #dropValue?: () => void;
 
   /**
@@ -21,7 +21,7 @@ export class ValueJoint<out T, in TIn extends T = T> extends DataJoint<T, TIn> {
    *
    * @param value - Initial value to sink to the added sinks until a new one accepted.
    */
-  constructor(value: T) {
+  constructor(value: TOut) {
     super();
     this.#value = value;
     this.supply.whenOff(() => {
@@ -35,7 +35,7 @@ export class ValueJoint<out T, in TIn extends T = T> extends DataJoint<T, TIn> {
    *
    * Reset to initial one once the {@link supply joint supply} cut off.
    */
-  get value(): T {
+  get value(): TOut {
     return this.#value;
   }
 
@@ -70,7 +70,7 @@ export class ValueJoint<out T, in TIn extends T = T> extends DataJoint<T, TIn> {
    *
    * @returns Either nothing, or a promise-like instance resolved when the sink added.
    */
-  protected async sinkAdded(sink: DataSink<T>, _sinkSupply: Supply<void>): Promise<void> {
+  protected async sinkAdded(sink: DataSink<TOut>, _sinkSupply: Supply<void>): Promise<void> {
     await sink(this.value);
   }
 

--- a/src/seeps/joint.seep.spec.ts
+++ b/src/seeps/joint.seep.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from '@jest/globals';
+import { Supply } from '@proc7ts/supply';
+import { DataJoint } from '../joints/data-joint.js';
+import { jointSeep } from './joint.seep.js';
+
+describe('jointSeep', () => {
+  it('pours data', async () => {
+    const source = new DataJoint<number>();
+    const out = jointSeep<number>()(source.faucet);
+
+    const supply1 = new Supply();
+    const sank1: number[] = [];
+    const whenSank1 = out(value => {
+      sank1.push(value);
+    }, supply1);
+
+    source.pass(1);
+    source.pass(2);
+    source.pass(3);
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(sank1).toEqual([1, 2, 3]);
+
+    const sank2: number[] = [];
+    const supply2 = new Supply();
+    const whenSank2 = out(value => {
+      sank2.push(value);
+    }, supply2);
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(sank1).toEqual([1, 2, 3]);
+    expect(sank2).toEqual([3]);
+
+    source.pass(4);
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(sank1).toEqual([1, 2, 3, 4]);
+    expect(sank2).toEqual([3, 4]);
+
+    supply1.done();
+    source.pass(5);
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(sank1).toEqual([1, 2, 3, 4]);
+    expect(sank2).toEqual([3, 4, 5]);
+
+    supply2.done();
+    await whenSank1;
+    await whenSank2;
+  });
+});

--- a/src/seeps/joint.seep.spec.ts
+++ b/src/seeps/joint.seep.spec.ts
@@ -41,9 +41,46 @@ describe('jointSeep', () => {
     source.pass(5);
 
     await new Promise<void>(resolve => setImmediate(resolve));
+    await whenSank1;
     expect(sank1).toEqual([1, 2, 3, 4]);
     expect(sank2).toEqual([3, 4, 5]);
 
+    supply2.done();
+
+    await whenSank2;
+  });
+  it('ignores poured data without sinks', async () => {
+    const source = new DataJoint<number>();
+    const out = jointSeep<number>()(source.faucet);
+
+    const supply1 = new Supply();
+    const sank1: number[] = [];
+    const whenSank1 = out(value => {
+      sank1.push(value);
+    }, supply1);
+
+    source.pass(1);
+    source.pass(2);
+    source.pass(3);
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(sank1).toEqual([1, 2, 3]);
+
+    supply1.off();
+
+    const sank2: number[] = [];
+    const supply2 = new Supply();
+    const whenSank2 = out(value => {
+      sank2.push(value);
+    }, supply2);
+
+    source.pass(4);
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(sank1).toEqual([1, 2, 3]);
+    expect(sank2).toEqual([4]); // Would be `[3, 4]` if buffered value reported.
+
+    supply1.done();
     supply2.done();
     await whenSank1;
     await whenSank2;

--- a/src/seeps/joint.seep.ts
+++ b/src/seeps/joint.seep.ts
@@ -1,9 +1,16 @@
+import { noop } from '@proc7ts/primitives';
+import { SupplyOut } from '@proc7ts/supply';
+import { IntakeFaucet } from '../data-faucet.js';
 import { DataSeep } from '../data-seep.js';
+import { DataSink } from '../data-sink.js';
 import { BufferJoint } from '../joints/buffer-joint.js';
 import { DataJoint } from '../joints/data-joint.js';
 
 /**
  * Creates data seep that pours data through the {@link DataJoint joint}.
+ *
+ * The output faucet creates joint and starts sinking values through it once the first sink started, and destroys
+ * the faucet once the last sink completed.
  *
  * @typeParam TIn - Input data type.
  * @typeParam TOut - Output data type.
@@ -16,12 +23,57 @@ export function jointSeep<TIn extends TOut, TOut = TIn>(
   createJoint: () => DataJoint<TIn, TOut> = () => new BufferJoint(1),
 ): DataSeep<TIn, TOut> {
   return input => {
-    const joint = createJoint();
-
-    const promise = input(joint.sink, joint.supply);
+    let state: JointSeep$State<TIn, TOut> | undefined;
 
     return async (sink, sinkSupply) => {
-      await Promise.race([promise, joint.faucet(sink, sinkSupply)]);
+      if (!state) {
+        const joint = createJoint();
+
+        state = new JointSeep$State(input, joint);
+        joint.supply.whenOff(() => {
+          state = undefined;
+        });
+      }
+
+      await state.pour(sink, sinkSupply);
     };
   };
+}
+
+class JointSeep$State<in TIn extends TOut, out TOut = TIn> {
+
+  readonly #joint: DataJoint<TIn, TOut>;
+  #refCount = 0;
+  readonly #whenSank: Promise<void>;
+
+  constructor(input: IntakeFaucet<TIn>, joint: DataJoint<TIn, TOut>) {
+    this.#joint = joint;
+    this.#whenSank = input(joint.sink, joint.supply);
+  }
+
+  async pour(sink: DataSink<TOut>, sinkSupply: SupplyOut | undefined): Promise<void> {
+    ++this.#refCount;
+
+    let done = (): void => {
+      done = noop; // Make sure this is called only once.
+      if (!--this.#refCount) {
+        this.#joint.supply.done();
+      }
+    };
+
+    sinkSupply?.whenOff(() => done()); // Decrease ref count immediately.
+
+    try {
+      await this.#joint.faucet(sink, sinkSupply);
+    } finally {
+      done(); // Ensure ref count decreased even without sink supply.
+    }
+
+    if (!this.#refCount) {
+      // Last sink.
+      // Wait for all data sank by joint.
+      return await this.#whenSank;
+    }
+  }
+
 }

--- a/src/seeps/joint.seep.ts
+++ b/src/seeps/joint.seep.ts
@@ -1,0 +1,27 @@
+import { DataSeep } from '../data-seep.js';
+import { BufferJoint } from '../joints/buffer-joint.js';
+import { DataJoint } from '../joints/data-joint.js';
+
+/**
+ * Creates data seep that pours data through the {@link DataJoint joint}.
+ *
+ * @typeParam TIn - Input data type.
+ * @typeParam TOut - Output data type.
+ * @param createJoint - Data joint creator function. By default, creates a {@link BufferJoint} with buffer capacity
+ * of `1`.
+ *
+ * @returns New data seep.
+ */
+export function jointSeep<TIn extends TOut, TOut = TIn>(
+  createJoint: () => DataJoint<TIn, TOut> = () => new BufferJoint(1),
+): DataSeep<TIn, TOut> {
+  return input => {
+    const joint = createJoint();
+
+    const promise = input(joint.sink, joint.supply);
+
+    return async (sink, sinkSupply) => {
+      await Promise.race([promise, joint.faucet(sink, sinkSupply)]);
+    };
+  };
+}

--- a/src/seeps/mod.ts
+++ b/src/seeps/mod.ts
@@ -1,5 +1,6 @@
 export * from './concat.seep.js';
 export * from './filter.seep.js';
+export * from './joint.seep.js';
 export * from './map.seep.js';
 export * from './merge.seep.js';
 export * from './or.seep.js';


### PR DESCRIPTION
- Switch positions of in/out joint type parameters
- Implement `jointSeep()`
- Additional test
- Ref-count sinks of joint seep
